### PR TITLE
Add TWSend functionality with custom ThoughtWorks prompt support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "claude-dev",
-	"displayName": "Cline",
+	"displayName": "TWCline",
 	"description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
 	"version": "3.14.0",
 	"icon": "assets/icons/icon.png",
@@ -48,7 +48,7 @@
 			"activitybar": [
 				{
 					"id": "claude-dev-ActivityBar",
-					"title": "Cline",
+					"title": "TWCline",
 					"icon": "assets/icons/icon.svg"
 				}
 			]

--- a/src/core/prompts/custom/thoughtworks.ts
+++ b/src/core/prompts/custom/thoughtworks.ts
@@ -2,12 +2,12 @@ import { McpHub } from "../../../services/mcp/McpHub"
 import { BrowserSettings } from "../../../shared/BrowserSettings"
 
 export const THOUGHTWORKS_SYSTEM_PROMPT = async (
-    cwd: string,
-    supportsBrowserUse: boolean,
-    mcpHub?: McpHub,
-    browserSettings?: BrowserSettings
+	cwd: string,
+	supportsBrowserUse: boolean,
+	mcpHub?: McpHub,
+	browserSettings?: BrowserSettings,
 ): Promise<string> => {
-    return `You are Cline, a ThoughtWorks engineer's AI pair programmer. Your job is to help ThoughtWorks employees write high-quality, maintainable code that reflects our values and practices.
+	return `You are Cline, a ThoughtWorks engineer's AI pair programmer. Your job is to help ThoughtWorks employees write high-quality, maintainable code that reflects our values and practices.
 
 Your guiding principles
 

--- a/src/core/prompts/custom/thoughtworks.ts
+++ b/src/core/prompts/custom/thoughtworks.ts
@@ -1,0 +1,65 @@
+import { McpHub } from "../../../services/mcp/McpHub"
+import { BrowserSettings } from "../../../shared/BrowserSettings"
+
+export const THOUGHTWORKS_SYSTEM_PROMPT = async (
+    cwd: string,
+    supportsBrowserUse: boolean,
+    mcpHub?: McpHub,
+    browserSettings?: BrowserSettings
+): Promise<string> => {
+    return `You are Cline, a ThoughtWorks engineer's AI pair programmer. Your job is to help ThoughtWorks employees write high-quality, maintainable code that reflects our values and practices.
+
+Your guiding principles
+
+Integrity, Respect & Responsibility: Always treat the code, the problem, and your human collaborator with honesty and empathy.
+
+Agile & XP Practices:
+
+Communication: Ask clarifying questions when requirements aren't clear.
+
+Simplicity: Solve today's problem with the simplest design that could possibly work.
+
+Feedback & Courage: Encourage rapid feedback loops through thorough testing and reviews.
+
+Respect: Honor your partner's ideas and learn together.
+
+Development process
+
+Test-Driven Development (TDD):
+
+Write failing unit tests before writing any production code.
+
+Keep tests small, focused, and easy to read.
+
+Behavior-Driven Development (BDD):
+
+Define high-level behaviors in plain language.
+
+Map behaviors to executable specifications.
+
+Pair Programming Ready:
+
+Structure code in small, self-contained functions or classes.
+
+Use clear, concise comments to explain "why," not "what."
+
+Continuous Improvement & Quality:
+
+Design for CI/CD: modular components, clear interfaces, and automated pipelines.
+
+Apply Object Calisthenics (e.g., one level of indentation per method, no primitives for domain objects) to keep code clean.
+
+Refactor mercilessly after tests pass.
+
+When you respond
+
+Provide example code snippets in the user's preferred language or framework.
+
+Highlight which ThoughtWorks practice you're applying ("Here's the failing test—TDD step 1," "This BDD scenario covers…").
+
+Explain how your suggestion upholds our values and accelerates feedback.
+
+Offer pointers for continuous integration, automated testing, and deployment.
+
+Your goal is to empower ThoughtWorks engineers to deliver robust, well-tested software with speed and confidence—one small, clean step at a time.`
+}

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -184,7 +184,9 @@ export class Task {
 		task?: string,
 		images?: string[],
 		historyItem?: HistoryItem,
+		customSystemPrompt?: string,
 	) {
+		this.customSystemPrompt = customSystemPrompt;
 		this.context = context
 		this.mcpHub = mcpHub
 		this.workspaceTracker = workspaceTracker
@@ -1428,6 +1430,8 @@ export class Task {
 		return statusCode && !message.includes(statusCode.toString()) ? `${statusCode} - ${message}` : message
 	}
 
+	private customSystemPrompt?: string
+
 	async *attemptApiRequest(previousApiReqIndex: number): ApiStream {
 		// Wait for MCP servers to be connected before generating system prompt
 		await pWaitFor(() => this.mcpHub.isConnecting !== true, { timeout: 10_000 }).catch(() => {
@@ -1440,7 +1444,7 @@ export class Task {
 
 		const supportsBrowserUse = modelSupportsBrowserUse && !disableBrowserTool // only enable browser use if the model supports it and the user hasn't disabled it
 
-		let systemPrompt = await SYSTEM_PROMPT(cwd, supportsBrowserUse, this.mcpHub, this.browserSettings)
+		let systemPrompt = this.customSystemPrompt || await SYSTEM_PROMPT(cwd, supportsBrowserUse, this.mcpHub, this.browserSettings)
 
 		let settingsCustomInstructions = this.customInstructions?.trim()
 		const preferredLanguage = getLanguageKey(

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -186,7 +186,7 @@ export class Task {
 		historyItem?: HistoryItem,
 		customSystemPrompt?: string,
 	) {
-		this.customSystemPrompt = customSystemPrompt;
+		this.customSystemPrompt = customSystemPrompt
 		this.context = context
 		this.mcpHub = mcpHub
 		this.workspaceTracker = workspaceTracker
@@ -1444,7 +1444,8 @@ export class Task {
 
 		const supportsBrowserUse = modelSupportsBrowserUse && !disableBrowserTool // only enable browser use if the model supports it and the user hasn't disabled it
 
-		let systemPrompt = this.customSystemPrompt || await SYSTEM_PROMPT(cwd, supportsBrowserUse, this.mcpHub, this.browserSettings)
+		let systemPrompt =
+			this.customSystemPrompt || (await SYSTEM_PROMPT(cwd, supportsBrowserUse, this.mcpHub, this.browserSettings))
 
 		let settingsCustomInstructions = this.customInstructions?.trim()
 		const preferredLanguage = getLanguageKey(

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -47,6 +47,7 @@ export interface ExtensionMessage {
 		| "fileSearchResults"
 		| "grpc_response" // New type for gRPC responses
 		| "setActiveQuote"
+		| "sendWithCustomPrompt" // New type for sending with custom prompt
 	text?: string
 	action?:
 		| "chatButtonClicked"

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -12,6 +12,7 @@ export interface WebviewMessage {
 		| "apiConfiguration"
 		| "webviewDidLaunch"
 		| "newTask"
+		| "sendWithCustomPrompt"
 		| "condense"
 		| "askResponse"
 		| "didShowAnnouncement"
@@ -69,6 +70,7 @@ export interface WebviewMessage {
 
 	// | "relaunchChromeDebugMode"
 	text?: string
+	message?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -452,7 +452,7 @@ export const ChatRowContent = ({
 							{toolIcon("edit")}
 							{tool.operationIsLocatedInWorkspace === false &&
 								toolIcon("sign-out", "yellow", -90, "This file is outside of your workspace")}
-							<span style={{ fontWeight: "bold" }}>Cline wants to edit this file:</span>
+							<span style={{ fontWeight: "bold" }}>TWCline wants to edit this file:</span>
 						</div>
 						<CodeAccordian
 							// isLoading={message.partial}
@@ -490,7 +490,7 @@ export const ChatRowContent = ({
 								toolIcon("sign-out", "yellow", -90, "This file is outside of your workspace")}
 							<span style={{ fontWeight: "bold" }}>
 								{/* {message.type === "ask" ? "" : "Cline read this file:"} */}
-								Cline wants to read this file:
+								TWCline wants to read this file:
 							</span>
 						</div>
 						<div

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -921,19 +921,23 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		}, [chatSettings.mode, showModelSelector, submitApiConfig, inputValue, selectedImages])
 
 		useShortcut("Meta+Shift+a", onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
-		
+
 		// Add shortcut for TWSend (Option+Return on Mac, Alt+Enter on other platforms)
-		useShortcut("Alt+Enter", () => {
-			if (!textAreaDisabled) {
-				setIsTextAreaFocused(false);
-				// Send with TWSend flag
-				vscode.postMessage({
-					type: "sendWithCustomPrompt",
-					message: inputValue,
-					images: selectedImages.length > 0 ? selectedImages : undefined,
-				});
-			}
-		}, { disableTextInputs: false }) // Important to not disable text inputs so it works inside textarea
+		useShortcut(
+			"Alt+Enter",
+			() => {
+				if (!textAreaDisabled) {
+					setIsTextAreaFocused(false)
+					// Send with TWSend flag
+					vscode.postMessage({
+						type: "sendWithCustomPrompt",
+						message: inputValue,
+						images: selectedImages.length > 0 ? selectedImages : undefined,
+					})
+				}
+			},
+			{ disableTextInputs: false },
+		) // Important to not disable text inputs so it works inside textarea
 
 		const handleContextButtonClick = useCallback(() => {
 			if (textAreaDisabled) return
@@ -1494,28 +1498,26 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											onSend()
 										}
 									}}
-									style={{ fontSize: 15 }}
-								></div>
+									style={{ fontSize: 15 }}></div>
 								<div
 									className={`input-icon-button ${textAreaDisabled ? "disabled" : ""} codicon codicon-chevron-down`}
 									onClick={(e) => {
 										if (!textAreaDisabled) {
-											e.stopPropagation();
-											setShowSendDropdown(!showSendDropdown);
+											e.stopPropagation()
+											setShowSendDropdown(!showSendDropdown)
 										}
 									}}
-									style={{ 
+									style={{
 										fontSize: 12,
 										position: "absolute",
 										right: -10,
 										bottom: -2,
-										cursor: "pointer"
-									}}
-								></div>
-									<div
-										ref={sendDropdownRef}
-										style={{
-											display: showSendDropdown ? "block" : "none",
+										cursor: "pointer",
+									}}></div>
+								<div
+									ref={sendDropdownRef}
+									style={{
+										display: showSendDropdown ? "block" : "none",
 										position: "absolute",
 										bottom: "100%",
 										right: 0,
@@ -1526,28 +1528,27 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 										zIndex: 2000,
 										marginBottom: "10px",
 										marginRight: "2px",
-											boxShadow: "0 4px 12px rgba(0, 0, 0, 0.2)",
-											minWidth: "180px",
-											transform: showSendDropdown ? "translateY(0)" : "translateY(4px)",
-											opacity: showSendDropdown ? 1 : 0,
-											transition: "transform 0.15s ease-out, opacity 0.15s ease-out",
-											overflow: "hidden",
+										boxShadow: "0 4px 12px rgba(0, 0, 0, 0.2)",
+										minWidth: "180px",
+										transform: showSendDropdown ? "translateY(0)" : "translateY(4px)",
+										opacity: showSendDropdown ? 1 : 0,
+										transition: "transform 0.15s ease-out, opacity 0.15s ease-out",
+										overflow: "hidden",
+									}}>
+									{/* Caret pointing down */}
+									<div
+										style={{
+											position: "absolute",
+											bottom: "-5px",
+											right: "10px",
+											width: "10px",
+											height: "10px",
+											backgroundColor: "var(--vscode-editor-background)",
+											border: "1px solid var(--vscode-input-border)",
+											borderWidth: "0 1px 1px 0",
+											transform: "rotate(45deg)",
 										}}
-									>
-										{/* Caret pointing down */}
-										<div
-											style={{
-												position: "absolute",
-												bottom: "-5px",
-												right: "10px",
-												width: "10px",
-												height: "10px",
-												backgroundColor: "var(--vscode-editor-background)",
-												border: "1px solid var(--vscode-input-border)",
-												borderWidth: "0 1px 1px 0",
-												transform: "rotate(45deg)",
-											}}
-										/>
+									/>
 									<div
 										style={{
 											padding: "8px 12px",
@@ -1556,35 +1557,38 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 											color: "var(--vscode-input-foreground)",
 											display: "flex",
 											justifyContent: "space-between",
-											alignItems: "center"
+											alignItems: "center",
 										}}
 										onClick={() => {
 											if (!textAreaDisabled) {
-												setIsTextAreaFocused(false);
+												setIsTextAreaFocused(false)
 												// Hide dropdown
-												setShowSendDropdown(false);
+												setShowSendDropdown(false)
 												// Send with TWSend flag
 												vscode.postMessage({
 													type: "sendWithCustomPrompt",
 													message: inputValue,
 													images: selectedImages.length > 0 ? selectedImages : undefined,
-												});
+												})
 											}
 										}}
 										onMouseOver={(e) => {
-											(e.target as HTMLDivElement).style.backgroundColor = "var(--vscode-list-hoverBackground)";
+											;(e.target as HTMLDivElement).style.backgroundColor =
+												"var(--vscode-list-hoverBackground)"
 										}}
 										onMouseOut={(e) => {
-											(e.target as HTMLDivElement).style.backgroundColor = "";
-										}}
-									>
+											;(e.target as HTMLDivElement).style.backgroundColor = ""
+										}}>
 										<span>TWSend</span>
-										<span style={{
-											marginLeft: "8px",
-											fontSize: "10px",
-											opacity: 0.7,
-											whiteSpace: "nowrap"
-										}}>⌥↩</span>
+										<span
+											style={{
+												marginLeft: "8px",
+												fontSize: "10px",
+												opacity: 0.7,
+												whiteSpace: "nowrap",
+											}}>
+											⌥↩
+										</span>
 									</div>
 								</div>
 							</div>

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -276,6 +276,13 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		const shiftHoldTimerRef = useRef<NodeJS.Timeout | null>(null)
 		const [showUnsupportedFileError, setShowUnsupportedFileError] = useState(false)
 		const unsupportedFileTimerRef = useRef<NodeJS.Timeout | null>(null)
+		const sendDropdownRef = useRef<HTMLDivElement | null>(null)
+		const [showSendDropdown, setShowSendDropdown] = useState(false)
+
+		// Add click-away handler for the send dropdown
+		useClickAway(sendDropdownRef, () => {
+			setShowSendDropdown(false)
+		})
 
 		const [fileSearchResults, setFileSearchResults] = useState<SearchResult[]>([])
 		const [searchLoading, setSearchLoading] = useState(false)
@@ -914,6 +921,19 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		}, [chatSettings.mode, showModelSelector, submitApiConfig, inputValue, selectedImages])
 
 		useShortcut("Meta+Shift+a", onModeToggle, { disableTextInputs: false }) // important that we don't disable the text input here
+		
+		// Add shortcut for TWSend (Option+Return on Mac, Alt+Enter on other platforms)
+		useShortcut("Alt+Enter", () => {
+			if (!textAreaDisabled) {
+				setIsTextAreaFocused(false);
+				// Send with TWSend flag
+				vscode.postMessage({
+					type: "sendWithCustomPrompt",
+					message: inputValue,
+					images: selectedImages.length > 0 ? selectedImages : undefined,
+				});
+			}
+		}, { disableTextInputs: false }) // Important to not disable text inputs so it works inside textarea
 
 		const handleContextButtonClick = useCallback(() => {
 			if (textAreaDisabled) return
@@ -1439,7 +1459,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					<div
 						style={{
 							position: "absolute",
-							right: 23,
+							right: 28,
 							display: "flex",
 							alignItems: "flex-center",
 							height: textAreaBaseHeight || 31,
@@ -1464,16 +1484,110 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									fontSize: 16.5,
 								}}
 							/> */}
-							<div
-								data-testid="send-button"
-								className={`input-icon-button ${textAreaDisabled ? "disabled" : ""} codicon codicon-send`}
-								onClick={() => {
-									if (!textAreaDisabled) {
-										setIsTextAreaFocused(false)
-										onSend()
-									}
-								}}
-								style={{ fontSize: 15 }}></div>
+							<div style={{ position: "relative" }}>
+								<div
+									data-testid="send-button"
+									className={`input-icon-button ${textAreaDisabled ? "disabled" : ""} codicon codicon-send`}
+									onClick={() => {
+										if (!textAreaDisabled) {
+											setIsTextAreaFocused(false)
+											onSend()
+										}
+									}}
+									style={{ fontSize: 15 }}
+								></div>
+								<div
+									className={`input-icon-button ${textAreaDisabled ? "disabled" : ""} codicon codicon-chevron-down`}
+									onClick={(e) => {
+										if (!textAreaDisabled) {
+											e.stopPropagation();
+											setShowSendDropdown(!showSendDropdown);
+										}
+									}}
+									style={{ 
+										fontSize: 12,
+										position: "absolute",
+										right: -10,
+										bottom: -2,
+										cursor: "pointer"
+									}}
+								></div>
+									<div
+										ref={sendDropdownRef}
+										style={{
+											display: showSendDropdown ? "block" : "none",
+										position: "absolute",
+										bottom: "100%",
+										right: 0,
+										backgroundColor: "var(--vscode-editor-background)",
+										border: "1px solid var(--vscode-input-border)",
+										borderRadius: "6px",
+										padding: "8px 0",
+										zIndex: 2000,
+										marginBottom: "10px",
+										marginRight: "2px",
+											boxShadow: "0 4px 12px rgba(0, 0, 0, 0.2)",
+											minWidth: "180px",
+											transform: showSendDropdown ? "translateY(0)" : "translateY(4px)",
+											opacity: showSendDropdown ? 1 : 0,
+											transition: "transform 0.15s ease-out, opacity 0.15s ease-out",
+											overflow: "hidden",
+										}}
+									>
+										{/* Caret pointing down */}
+										<div
+											style={{
+												position: "absolute",
+												bottom: "-5px",
+												right: "10px",
+												width: "10px",
+												height: "10px",
+												backgroundColor: "var(--vscode-editor-background)",
+												border: "1px solid var(--vscode-input-border)",
+												borderWidth: "0 1px 1px 0",
+												transform: "rotate(45deg)",
+											}}
+										/>
+									<div
+										style={{
+											padding: "8px 12px",
+											cursor: "pointer",
+											fontSize: "12px",
+											color: "var(--vscode-input-foreground)",
+											display: "flex",
+											justifyContent: "space-between",
+											alignItems: "center"
+										}}
+										onClick={() => {
+											if (!textAreaDisabled) {
+												setIsTextAreaFocused(false);
+												// Hide dropdown
+												setShowSendDropdown(false);
+												// Send with TWSend flag
+												vscode.postMessage({
+													type: "sendWithCustomPrompt",
+													message: inputValue,
+													images: selectedImages.length > 0 ? selectedImages : undefined,
+												});
+											}
+										}}
+										onMouseOver={(e) => {
+											(e.target as HTMLDivElement).style.backgroundColor = "var(--vscode-list-hoverBackground)";
+										}}
+										onMouseOut={(e) => {
+											(e.target as HTMLDivElement).style.backgroundColor = "";
+										}}
+									>
+										<span>TWSend</span>
+										<span style={{
+											marginLeft: "8px",
+											fontSize: "10px",
+											opacity: 0.7,
+											whiteSpace: "nowrap"
+										}}>⌥↩</span>
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Description
This PR adds a new "TWSend" feature to the Cline extension that uses a custom system prompt focused on Thoughtworks best practices when generating responses.

## Changes
- Added dropdown to the send button in the chat interface
- Created a new "TWSend" option in the dropdown menu
- Implemented custom system prompt for Thoughtworks-focused responses
- Added supporting infrastructure for custom prompt selection

## Files Changed
- webview-ui/src/components/chat/ChatTextArea.tsx: Added dropdown UI to send button
- src/shared/ExtensionMessage.ts: Added "sendWithCustomPrompt" message type
- src/shared/WebviewMessage.ts: Added "message" property to WebviewMessage
- src/core/controller/index.ts: Added handler for "sendWithCustomPrompt" message
- src/core/task/index.ts: Modified to support custom system prompts
- src/core/prompts/custom/thoughtworks.ts: Created new custom prompt

## Testing
- Verified code compiles without errors
- Manually tested TWSend button functionality

## Screenshots
[If you have any screenshots of the UI changes, add them here]
